### PR TITLE
Story 24 Allow developers to add links to their profile information

### DIFF
--- a/app/Actions/Profile/UpdateSocialInformation.php
+++ b/app/Actions/Profile/UpdateSocialInformation.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Actions\Profile;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Auth\AuthenticationException;
+
+class UpdateSocialInformation
+{
+
+    /**
+     * Validate and update the given user's social links.
+     *
+     * @param array<string, string|null> $input
+     *
+     * @throws AuthenticationException
+     */
+    public function update(User $user, array $input): void
+    {
+
+        if ($user === null) {
+            throw new AuthenticationException();
+        }
+
+        Validator::make($input, [
+            'website' => ['nullable', 'url'],
+            'linkedin' => ['nullable', 'url'],
+            'github' => ['nullable', 'url'],
+            'twitter' => ['nullable', 'url'],
+        ])->validateWithBag('updateSocialInformation');
+
+
+        $user->links = json_encode([
+            'website' => $input['website'],
+            'linkedin' => $input['linkedin'],
+            'github' =>  $input['github'],
+            'twitter' => $input['twitter'],
+        ]);
+
+        $user->save();
+    }
+}

--- a/app/Http/Livewire/UpdateSocialInformationForm.php
+++ b/app/Http/Livewire/UpdateSocialInformationForm.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use App\Actions\Profile\UpdateSocialInformation;
+
+
+class UpdateSocialInformationForm extends Component
+{
+    /**
+     * @var array{website: ?string, linkedin: ?string, github: ?string, twitter: ?string} $state
+     */
+    public array $state;
+
+    public function mount(): void
+    {
+        $user = Auth::user();
+        $links = json_decode($user->links);
+        $this->state = [
+            'website' => $links->website ?? null,
+            'linkedin' => $links->linkedin ?? null,
+            'github' => $links->github ?? null,
+            'twitter' => $links->twitter ?? null,
+        ];
+    }
+
+    public function updateSocialInformationForm(UpdateSocialInformation $updater): void
+    {
+        $this->resetErrorBag();
+        $updater->update(
+            Auth::user(),
+            $this->state
+        );
+
+        $this->emit('saved');
+    }
+
+    public function render(): View|\Closure|string
+    {
+        return view('livewire.update-social-information-form');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,10 @@
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
         ],
+        "post-install-cmd": [
+            "Illuminate\\Foundation\\ComposerScripts::postInstall",
+            "@php artisan storage:link"
+        ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],

--- a/database/migrations/2023_05_02_161155_add_links_column_to_user_table.php
+++ b/database/migrations/2023_05_02_161155_add_links_column_to_user_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->json('links')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'links',
+            ]);
+        });
+    }
+};

--- a/resources/views/components/main-menu.blade.php
+++ b/resources/views/components/main-menu.blade.php
@@ -148,40 +148,6 @@
                                         {{ __('Log Out') }}
                                     </x-responsive-nav-link>
                                 </form>
-
-                                <!-- Team Management -->
-                                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
-                                    <div class="border-t border-gray-200"></div>
-
-                                    <div class="block px-4 py-2 text-xs text-gray-400">
-                                        {{ __('Manage Team') }}
-                                    </div>
-
-                                    <!-- Team Settings -->
-                                    <x-responsive-nav-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}"
-                                        :active="request()->routeIs('teams.show')">
-                                        {{ __('Team Settings') }}
-                                    </x-responsive-nav-link>
-
-                                    @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
-                                        <x-responsive-nav-link href="{{ route('teams.create') }}" :active="request()->routeIs('teams.create')">
-                                            {{ __('Create New Team') }}
-                                        </x-responsive-nav-link>
-                                    @endcan
-
-                                    <!-- Team Switcher -->
-                                    @if (Auth::user()->allTeams()->count() > 1)
-                                        <div class="border-t border-gray-200"></div>
-
-                                        <div class="block px-4 py-2 text-xs text-gray-400">
-                                            {{ __('Switch Teams') }}
-                                        </div>
-
-                                        @foreach (Auth::user()->allTeams() as $team)
-                                            <x-switchable-team :team="$team" component="responsive-nav-link" />
-                                        @endforeach
-                                    @endif
-                                @endif
                             </div>
                         </div>
                     @else

--- a/resources/views/livewire/update-social-information-form.blade.php
+++ b/resources/views/livewire/update-social-information-form.blade.php
@@ -1,0 +1,48 @@
+<x-form-section submit="updateSocialInformationForm">
+    <x-slot name="title">
+        {{ __('Online presence') }}
+    </x-slot>
+
+    <x-slot name="description">
+        {{ __('Where can people learn more about you and your work?') }}
+    </x-slot>
+
+    <x-slot name="form">
+        
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="website" value="{{ __('Website URL') }}" />
+            <x-input id="website" type="text" class="mt-1 block w-full" wire:model.defer="state.website" autocomplete="website" placeholder="https://example.com" />
+            <x-input-error for="website" class="mt-2" />
+        </div>
+
+        <div class="col-span-6 sm:col-span-4" >
+            <x-label for="linkedin" value="{{ __('LinkedIn URL') }}" />
+            <x-input id="linkedin" type="text" class="mt-1 block w-full" wire:model.defer="state.linkedin" autocomplete="linkedin" placeholder="https://linkedin.com/in/username/" />
+            <x-input-error for="linkedin" class="mt-2" />
+        </div>
+
+        <div class="col-span-6 sm:col-span-4" >
+            <x-label for="twitter" value="{{ __('Twitter username') }}" />
+            <x-input id="twitter" type="text" class="mt-1 block w-full" wire:model.defer="state.twitter" autocomplete="twitter" placeholder="http://twitter.com/username" />
+            <x-input-error for="twitter" class="mt-2" />
+        </div>
+
+        <div class="col-span-6 sm:col-span-4" >
+            <x-label for="github" value="{{ __('Github username') }}" />
+            <x-input id="github" type="text" class="mt-1 block w-full" wire:model.defer="state.github" autocomplete="github" placeholder="http://github.com/username" />
+            <x-input-error for="github" class="mt-2" />
+        </div>
+
+
+    </x-slot>
+
+    <x-slot name="actions">
+        <x-action-message class="mr-3" on="saved">
+            {{ __('Saved.') }}
+        </x-action-message>
+
+        <x-button wire:loading.attr="disabled" wire:target="photo">
+            {{ __('Save') }}
+        </x-button>
+    </x-slot>
+</x-form-section>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -16,6 +16,9 @@
             <livewire:update-developer-information />
             <x-section-border />
 
+            <livewire:update-social-information-form />
+            <x-section-border />
+
             @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updatePasswords()))
                 <div class="mt-10 sm:mt-0">
                     @livewire('profile.update-password-form')

--- a/tests/Feature/UpdateSocialInformationFormTest.php
+++ b/tests/Feature/UpdateSocialInformationFormTest.php
@@ -25,6 +25,8 @@ class UpdateSocialInformationFormTest extends TestCase
 
     public function test_form_section_renders_correctly()
     {
+        $this->actingAs($user = User::factory()->create());
+
         Livewire::test(UpdateSocialInformationForm::class)
             ->assertSee(__('Online presence'))
             ->assertSee(__('Where can people learn more about you and your work?'))
@@ -56,6 +58,8 @@ class UpdateSocialInformationFormTest extends TestCase
 
     public function test_form_section_validates_valid_urls()
     {
+        $this->actingAs($user = User::factory()->create());
+
         Livewire::test(UpdateSocialInformationForm::class)
             ->set('state', [
                 'website' => 'invalid-url',

--- a/tests/Feature/UpdateSocialInformationFormTest.php
+++ b/tests/Feature/UpdateSocialInformationFormTest.php
@@ -5,16 +5,14 @@ namespace Tests\Feature;
 use Tests\TestCase;
 use App\Models\User;
 use Livewire\Livewire;
-use App\Http\Livewire\FormSection;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Http\Livewire\UpdateSocialInformationForm;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class UpdateSocialInformationFormTest extends TestCase
 {
     use RefreshDatabase;
-    /** @test */
-    public function the_component_can_render(): void
+
+    public function test_the_component_can_render(): void
     {
 
         $this->actingAs(User::factory()->create());
@@ -27,7 +25,7 @@ class UpdateSocialInformationFormTest extends TestCase
 
     public function test_form_section_renders_correctly()
     {
-        Livewire::test(FormSection::class)
+        Livewire::test(UpdateSocialInformationForm::class)
             ->assertSee(__('Online presence'))
             ->assertSee(__('Where can people learn more about you and your work?'))
             ->assertSee(__('Website URL'))
@@ -38,18 +36,27 @@ class UpdateSocialInformationFormTest extends TestCase
 
     public function test_can_update_social_information()
     {
-        Livewire::test(FormSection::class)
+        $this->actingAs($user = User::factory()->create());
+
+        $component = Livewire::test(UpdateSocialInformationForm::class)
             ->set('state.website', 'https://example.com')
             ->set('state.linkedin', 'https://linkedin.com/in/username')
             ->set('state.twitter', 'https://twitter.com/username')
             ->set('state.github', 'https://github.com/username')
             ->call('updateSocialInformationForm')
             ->assertEmitted('saved');
+
+        $links = json_decode($user->links);
+
+        $this->assertEquals($links->website, $component->state['website']);
+        $this->assertEquals($links->linkedin, $component->state['linkedin']);
+        $this->assertEquals($links->twitter, $component->state['twitter']);
+        $this->assertEquals($links->github, $component->state['github']);
     }
 
     public function test_form_section_validates_valid_urls()
     {
-        Livewire::test(FormSection::class)
+        Livewire::test(UpdateSocialInformationForm::class)
             ->set('state', [
                 'website' => 'invalid-url',
                 'linkedin' => 'linkedin.com/in/username',

--- a/tests/Feature/UpdateSocialInformationFormTest.php
+++ b/tests/Feature/UpdateSocialInformationFormTest.php
@@ -69,10 +69,10 @@ class UpdateSocialInformationFormTest extends TestCase
             ])
             ->call('updateSocialInformationForm')
             ->assertHasErrors([
-                'state.website' => 'url',
-                'state.linkedin' => 'url',
-                'state.twitter' => 'url',
-                'state.github' => 'url',
+                'website' => 'url',
+                'linkedin' => 'url',
+                'twitter' => 'url',
+                'github' => 'url',
             ]);
     }
 }

--- a/tests/Feature/UpdateSocialInformationFormTest.php
+++ b/tests/Feature/UpdateSocialInformationFormTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use Livewire\Livewire;
+use App\Http\Livewire\FormSection;
+use Illuminate\Foundation\Testing\WithFaker;
+use App\Http\Livewire\UpdateSocialInformationForm;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UpdateSocialInformationFormTest extends TestCase
+{
+    use RefreshDatabase;
+    /** @test */
+    public function the_component_can_render(): void
+    {
+
+        $this->actingAs(User::factory()->create());
+
+        $component = Livewire::test(UpdateSocialInformationForm::class);
+
+        $component->assertStatus(200);
+    }
+
+
+    public function test_form_section_renders_correctly()
+    {
+        Livewire::test(FormSection::class)
+            ->assertSee(__('Online presence'))
+            ->assertSee(__('Where can people learn more about you and your work?'))
+            ->assertSee(__('Website URL'))
+            ->assertSee(__('LinkedIn URL'))
+            ->assertSee(__('Twitter username'))
+            ->assertSee(__('Github username'));
+    }
+
+    public function test_can_update_social_information()
+    {
+        Livewire::test(FormSection::class)
+            ->set('state.website', 'https://example.com')
+            ->set('state.linkedin', 'https://linkedin.com/in/username')
+            ->set('state.twitter', 'https://twitter.com/username')
+            ->set('state.github', 'https://github.com/username')
+            ->call('updateSocialInformationForm')
+            ->assertEmitted('saved');
+    }
+
+    public function test_form_section_validates_valid_urls()
+    {
+        Livewire::test(FormSection::class)
+            ->set('state', [
+                'website' => 'invalid-url',
+                'linkedin' => 'linkedin.com/in/username',
+                'twitter' => 'twitter.com/username',
+                'github' => 'github.com/username',
+            ])
+            ->call('updateSocialInformationForm')
+            ->assertHasErrors([
+                'state.website' => 'url',
+                'state.linkedin' => 'url',
+                'state.twitter' => 'url',
+                'state.github' => 'url',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds a new field to the user table called "links" that allows users to add URLs for their social media profiles such as GitHub, LinkedIn, Twitter, and Website. The information is stored in JSON format for easy retrieval. Additionally, it removes unnecessary code from main-menu.blade.php, simplifying the codebase. Lastly, it adds a command to create a symbolic link for the storage directory after running composer install.


SCREEN

![image](https://user-images.githubusercontent.com/53806989/235780693-b2668d8b-c12a-43c5-96fa-bfafb0ef7421.png)
